### PR TITLE
Add useragent parametr

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ sites = [
      Character encoding of the website, e.g., 'utf-8' or 'iso-8859-1'.
    * <b>receiver</b> (optional)
      Overwrites global receiver specification.
+   * <b>useragent</b> (optional)
+     You can use it to set custom user-agent. For ex.: `'useragent': {'User-Agent':' Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'},` or preset `'useragent': 'Firefox',`.
 
 
  * We collect some XPath/CSS snippets at this place: <a href="https://github.com/Debianguru/MailWebsiteChanges/wiki/snippets">Snippet collection</a> - please feel free to add your own definitions!

--- a/mwc.py
+++ b/mwc.py
@@ -70,6 +70,7 @@ def parseSite(site):
         contentregex = site.get('contentregex', '')
         titleregex = site.get('titleregex', '')
         enc = site.get('encoding', defaultEncoding)
+        useragent = site.get('useragent', '')
 
         contentxpath = site.get('contentxpath', '')
         if contentxpath == '' and site.get('contentcss', '') != '':
@@ -85,6 +86,10 @@ def parseSite(site):
                         # run command and retrieve output
                         process = subprocess.Popen(uri[len(cmdscheme):], stdout=subprocess.PIPE, shell=True, close_fds=True)
                         file = process.stdout
+                if useragent == 'Firefox':
+                        file = urllib.request.urlopen(urllib.request.Request(uri,headers={'User-Agent':' Mozilla/5.0 (Windows NT 6.1; rv:38.0) Gecko/20100101 Firefox/38.0'}))
+                if useragent != '':
+                        file = urllib.request.urlopen(urllib.request.Request(uri,headers=useragent))
                 else:
                         # open website
                         file = urllib.request.urlopen(uri)


### PR DESCRIPTION
Use browser-like user-agent with broken websites.
For ex.: `'useragent': {'User-Agent':' Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'},` or preset `'useragent': 'Firefox',`.